### PR TITLE
fix(docs): correct pnpm install to pnpm add

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ npm install stunk
 yarn add stunk
 
 # pnpm
-pnpm install stunk
+pnpm add stunk
 
 # bun
 bun add stunk


### PR DESCRIPTION
pnpm does not add dependencies with `pnpm install <pkg>`.
The correct command is `pnpm add <pkg>`, equivalent to npm install / yarn add.

This change fixes the pnpm installation instructions.
